### PR TITLE
Fix unbound local if system pkgconf isn't available

### DIFF
--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -35,6 +35,22 @@ def test_fallback(mocker, monkeypatch):
     sys.exit.assert_called_with(0)
 
 
+def test_no_fallback(mocker, monkeypatch):
+    """Test that we don't fail if there's no system pkgconf and ours fails."""
+    mocker.patch('pkgconf.run_pkgconf', side_effect=subprocess.CalledProcessError(1, '(cmd)'))
+    mocker.patch('subprocess.run', return_value=subprocess.CompletedProcess(['(cmd)'], 0))
+    mocker.patch('sys.exit')
+
+    mocker.patch('shutil.which', return_value=None)
+
+    args = ['--libs', 'py-test-inexistent']
+    monkeypatch.setattr(sys, 'argv', ['(argv0)', *args])
+
+    pkgconf.__main__.main()
+
+    sys.exit.assert_called_with(1)
+
+
 def test_venv_redirect(mocker, monkeypatch):
     mocker.patch('subprocess.run', return_value=subprocess.CompletedProcess(['(cmd)'], 0))
     mocker.patch('sys.exit')


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/build/venv/build/bin/pkgconf", line 8, in <module>
    sys.exit(_entrypoint())
             ~~~~~~~~~~~^^
  File "/build/venv/build/lib/python3.13/site-packages/pkgconf/__main__.py", line 69, in _entrypoint
    main()
    ~~~~^^
  File "/build/venv/build/lib/python3.13/site-packages/pkgconf/__main__.py", line 42, in main
    sys.exit(process.returncode)
             ^^^^^^^
UnboundLocalError: cannot access local variable 'process' where it is not associated with a value
```