### PR TITLE
Remove --prefix argument causing errors on Python 3.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ source = 'https://github.com/pypackaging-native/pkgconf-pypi'
 
 [tool.meson-python.args]
 install = ['--tags=python-runtime']
-setup = ['--prefix=/build']
+# setup = ['--prefix=/build']
 
 [tool.cibuildwheel]
 # Build is Python-independent, so we select a single Python version (doesn't


### PR DESCRIPTION
Not exactly sure why this option is enabled, but it's causing a test failure on Windows/Python 3.13.