### PR TITLE
CI: improve ARM platform support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,10 +33,11 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
+          - ubuntu-24.04-arm
           - windows-latest
           - windows-11-arm
-          - macos-13
-          - macos-14
+          - macos-13      # x86-64
+          - macos-latest  # arm64
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -59,7 +60,7 @@ jobs:
           platforms: all
       - uses: pypa/cibuildwheel@2edf5784998b7b1ab70445baced23069e839541e # 3.0.0rc2
         env:
-          CIBW_ARCHS_LINUX: aarch64 ppc64le s390x
+          CIBW_ARCHS_LINUX: ppc64le s390x
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,7 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
+          - windows-11-arm
           - macos-13
           - macos-14
       fail-fast: false
@@ -41,7 +42,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: pypa/cibuildwheel@v2.18.1
+      - uses: pypa/cibuildwheel@2edf5784998b7b1ab70445baced23069e839541e # 3.0.0rc2
       - uses: actions/upload-artifact@v4
         if: always()
         with:
@@ -56,7 +57,7 @@ jobs:
       - uses: docker/setup-qemu-action@v3
         with:
           platforms: all
-      - uses: pypa/cibuildwheel@v2.18.1
+      - uses: pypa/cibuildwheel@2edf5784998b7b1ab70445baced23069e839541e # 3.0.0rc2
         env:
           CIBW_ARCHS_LINUX: aarch64 ppc64le s390x
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,19 +15,25 @@ concurrency:
 
 jobs:
   pytest:
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os:
-          - ubuntu
-          - windows
-          - macos
+          - ubuntu-latest
+          - windows-latest
+          - windows-11-arm
+          - macos-latest
         python:
           - '3.9'
           - '3.10'
           - '3.11'
           - '3.12'
           - '3.13'
+        exclude:
+          - os: windows-11-arm
+            python: '3.9'
+          - os: windows-11-arm
+            python: '3.10'
       fail-fast: false
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
- upgrade `cibuildwheel` to 3.0.0rc2
- add `win_arm64` wheels for Windows on Arm
- move Linux aarch64 wheel builds from cross compilation to native runners
- add `armv7l` wheels
- add CI testing on `windows-11-arm` runners

Green build log: https://github.com/rgommers/pkgconf-pypi/actions/runs/15516614776