### PR TITLE
pre-commit: update pyupgrade target Python version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,4 +59,4 @@ repos:
     rev: v3.21.2
     hooks:
     - id: pyupgrade
-      args: [--py38-plus]
+      args: [--py310-plus]


### PR DESCRIPTION
But then, since ruff [pyupgrade (UP)](https://docs.astral.sh/ruff/rules/#pyupgrade-up) rules have been selected, why keep pyupgrade?