### PR TITLE
py: no need to specify `src` for ruff ≥ 0.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,6 @@ strict = true
 
 [tool.ruff]
 line-length = 127
-src = ['src']
 
 [tool.ruff.format]
 quote-style = 'single'


### PR DESCRIPTION
https://astral.sh/blog/ruff-v0.6.0#migrating-to-v06

> By default, our `isort` rules now search inside `src/` directories when determining the list of package names that are likely to represent first-party code. This was always configurable, but it was suprising for many users that Ruff didn't understand this common project structure "out of the box".