### PR TITLE
ci: macOS 13 runner image is closing down

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,8 +36,8 @@ jobs:
           - ubuntu-24.04-arm
           - windows-latest
           - windows-11-arm
-          - macos-13      # x86-64
-          - macos-latest  # arm64
+          - macos-15-intel  # x86-64
+          - macos-latest    # arm64
       fail-fast: false
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/