### PR TITLE
py: Fix chained pkgconf invocation

### DIFF
--- a/src/pkgconf/__main__.py
+++ b/src/pkgconf/__main__.py
@@ -79,7 +79,7 @@ def _vanilla_entrypoint():
                 ),
                 stacklevel=2,
             )
-            sys.exit(subprocess.run([os.fspath(executable), *sys.argv[1:]]).returncode)
+        sys.exit(subprocess.run([os.fspath(executable), *sys.argv[1:]]).returncode)
 
 
 def _python_aware_entrypoint():


### PR DESCRIPTION
After https://github.com/pypackaging-native/pkgconf-pypi/pull/105, `pkgconf` invocation does nothing if `PKG_CONFIG_PATH` environment variable is set.
This might be due to an incorrect indentation around a warning message.